### PR TITLE
fixed bug where requirements were only added if they didn't have tags…

### DIFF
--- a/connect/__init__.py
+++ b/connect/__init__.py
@@ -5,7 +5,7 @@ from connect.adapters import Adapter
 from connect.governance import Governance
 from connect.utils.version_check import validate_version
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 __all__ = ["governance", "evidence", "utils"]
 

--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -52,7 +52,7 @@ class Adapter:
         metrics : dict or pd.DataFrame
             Dictionary of metrics. Form: {metric_type: value, ...}
         source : str
-            Label for what generated the metrics
+            Label for what generated the metrics. Added to metadata
         labels : dict
             Additional key/value pairs to act as labels for the evidence
         metadata : dict
@@ -122,7 +122,7 @@ class Adapter:
         data
             data to pass to evidence_fun
         source : str
-            Label for what generated the table. Added to metadata
+            Label for what generated the evidence. Added to metadata
         labels : dict
             Additional key/value pairs to act as labels for the evidence
         metadata : dict

--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -86,7 +86,7 @@ class Adapter:
         data: pd.DataFrame
             Dataframe to pass to evidence_fun. The DataFrame must have a "name" attribute
         source : str
-            Label for what generated the table
+            Label for what generated the table. Added to metadata
         labels : dict
             Additional key/value pairs to act as labels for the evidence
         metadata : dict
@@ -122,7 +122,7 @@ class Adapter:
         data
             data to pass to evidence_fun
         source : str
-            Label for what generated the table
+            Label for what generated the table. Added to metadata
         labels : dict
             Additional key/value pairs to act as labels for the evidence
         metadata : dict
@@ -136,7 +136,7 @@ class Adapter:
                 evidence_fun = partial(self._to_evidence, container_class=evidence_fun)
         except TypeError:
             pass
-        labels = {**(labels or {}), "source": source}
+        metadata = {**(metadata or {}), "source": source}
         evidence = evidence_fun(data=data, labels=labels, metadata=metadata)
         if overwrite_governance:
             self.governance.set_evidence(evidence)

--- a/connect/evidence/evidence_requirement.py
+++ b/connect/evidence/evidence_requirement.py
@@ -8,9 +8,9 @@ class EvidenceRequirement(ABC):
         data: dict,
     ):
         self._evidence_type: str = data.get("evidence_type")
-        self._label: dict = data.get("label")
+        self._label: dict = data.get("label", {})
         self._sensitive_features: List[str] = data.get("sensitive_features", [])
-        self._tags: dict = data.get("tags")
+        self._tags: dict = data.get("tags", {})
 
     def __str__(self) -> str:
         return f"{self.evidence_type}-EvidenceRequirement.label-{self.label}"

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -169,9 +169,7 @@ class Governance:
         if tags is None:
             tags = self.get_model_tags()
 
-        reqs = [
-            e for e in self._evidence_requirements if (not e.tags or e.tags == tags)
-        ]
+        reqs = [e for e in self._evidence_requirements if check_subset(e.tags, tags)]
         if verbose:
             self._print_evidence(reqs)
         return reqs

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -150,8 +150,15 @@ class Governance:
     def get_evidence_requirements(self, tags: dict = None, verbose=False):
         """
         Returns evidence requirements. Each evidence requirement can have optional tags
-        (a dictionary). Only returns requirements that have tags that match the model
-        (if provided), which are tags with the same tags as the model, or no tags.
+        (a dictionary). Returns requirements whose tags are a subset of the model's tags.
+
+        For example, imagine a model has two tags: {'risk': 'high', 'model_type': 'binary'}
+        and three requirements with the following tags:
+            req1 = {}
+            req2 = {'risk': 'high'}
+            req3 = {'risk': 'high', 'model_type': 'binary'}
+        In this case all requirements will apply. If the model risk was was 'low' only req_1 would
+        apply. If the 'model_type' was not 'binary' then only req1 and req2 would apply.
 
         Parameters
         ----------

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -183,7 +183,7 @@ class Governance:
         if self._model:
             return self._model["tags"]
         else:
-            return None
+            return {}
 
     def register(
         self,

--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -421,7 +421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {

--- a/tests/governance/test_governance.py
+++ b/tests/governance/test_governance.py
@@ -147,7 +147,7 @@ class TestGovernance:
         assert "metric" == req.evidence_type
         assert {"metric_type": "accuracy_score"} == req.label
 
-    def test_register_with_assessment_plan_file(self, gov):
+    def test_register_with_assessment_plan_file(self, gov, plan_file_mock):
 
         gov.register(assessment_plan_file="filename")
 

--- a/tests/governance/test_governance.py
+++ b/tests/governance/test_governance.py
@@ -19,6 +19,16 @@ EVIDENCE_REQUIREMENTS = [
         "label": {"table_name": "disaggregated_performance"},
         "sensitive_features": ["profession", "gender"],
     },
+    {
+        "evidence_type": "metric",
+        "label": {"metric_type": "precision"},
+        "tags": {"risk": "high"},
+    },
+    {
+        "evidence_type": "metric",
+        "label": {"metric_type": "recall"},
+        "tags": {"risk": "high", "model_type": "binary"},
+    },
 ]
 ASSESSMENT_PLAN_URL = f"http://api.credo.ai/api/v2/credoai/use_cases/${USE_CASE_ID}/assessment_plans/{POLICY_PACK_ID}"
 ASSESSMENT_PLAN = {
@@ -137,7 +147,7 @@ class TestGovernance:
         assert "metric" == req.evidence_type
         assert {"metric_type": "accuracy_score"} == req.label
 
-    def test_register_with_assessment_plan_file(self, gov, plan_file_mock):
+    def test_register_with_assessment_plan_file(self, gov):
 
         gov.register(assessment_plan_file="filename")
 
@@ -204,3 +214,12 @@ class TestGovernance:
         with tempfile.TemporaryDirectory() as tempDir:
             filename = f"{tempDir}/assessment.json"
             assert False == gov.export(filename)
+
+    def test_get_evidence_requirements(self, gov):
+        gov.register(assessment_plan=ASSESSMENT_PLAN_JSON_STR)
+        gov.set_artifacts(model="test", model_tags={"risk": "high"})
+        assert 4 == len(gov.get_evidence_requirements())
+        gov.set_artifacts(
+            model="test", model_tags={"risk": "high", "model_type": "binary"}
+        )
+        assert 5 == len(gov.get_evidence_requirements())


### PR DESCRIPTION
…, or were a perfect match

## Change description
The correct behavior should be adding a requirement whenever the requirement is a _subset_ of model tags.

For instance, if there are three requirements with the following tags:
```
req_1 = {}
req2 = {'risk': 'high'}
req3 = {'risk': 'high', 'model_type': 'binary'}
```

Then a model with the tag `{'risk': 'high'}` should have req1 and req2 applied. As should a model with tags `{'risk': 'high', 'model_type': 'regression'}`

Only a model with the tags `{'risk': 'high', 'model_type': 'binary'}` (or more) should have req2.


> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
