### PR TITLE
DEV-255 Separate model tags and version update from evidence uploading

### DIFF
--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -35,7 +35,9 @@ class Adapter:
     ):
 
         self.governance = governance
-        self.governance.set_artifacts(model_name, model_tags, model_version, assessment_dataset_name)
+        self.governance.set_artifacts(
+            model_name, model_tags, model_version, assessment_dataset_name
+        )
 
     def metrics_to_governance(
         self,

--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -30,11 +30,12 @@ class Adapter:
         governance: Governance,
         model_name: str,
         model_tags: Optional[dict] = None,
+        model_version: Optional[str] = None,
         assessment_dataset_name: str = None,
     ):
 
         self.governance = governance
-        self.governance.set_artifacts(model_name, model_tags, assessment_dataset_name)
+        self.governance.set_artifacts(model_name, model_tags, model_version, assessment_dataset_name)
 
     def metrics_to_governance(
         self,

--- a/connect/governance/credo_api.py
+++ b/connect/governance/credo_api.py
@@ -161,7 +161,9 @@ class CredoApi:
         path = f"use_cases/{use_case_id}/assessments/{id}"
         return self._client.get(path)
 
-    def update_use_case_model_link_tags(self, use_case_id: str, model_link_id: str, tags: dict):
+    def update_use_case_model_link_tags(
+        self, use_case_id: str, model_link_id: str, tags: dict
+    ):
         """
         Update tags of use case model link
 
@@ -186,9 +188,11 @@ class CredoApi:
 
         path = f"use_cases/{use_case_id}/model_links/{model_link_id}"
         data = {"tags": tags, "$type": "use_case_model_links", "id": model_link_id}
-        return self._client.patch(path, data)        
+        return self._client.patch(path, data)
 
-    def update_use_case_model_link_version(self, use_case_id: str, model_link_id: str, version: str):
+    def update_use_case_model_link_version(
+        self, use_case_id: str, model_link_id: str, version: str
+    ):
         """
         Update version of use case model link
 
@@ -212,5 +216,9 @@ class CredoApi:
         """
 
         path = f"use_cases/{use_case_id}/model_links/{model_link_id}"
-        data = {"model_version": version, "$type": "use_case_model_links", "id": model_link_id}
-        return self._client.patch(path, data)        
+        data = {
+            "model_version": version,
+            "$type": "use_case_model_links",
+            "id": model_link_id,
+        }
+        return self._client.patch(path, data)

--- a/connect/governance/credo_api.py
+++ b/connect/governance/credo_api.py
@@ -160,3 +160,30 @@ class CredoApi:
         """
         path = f"use_cases/{use_case_id}/assessments/{id}"
         return self._client.get(path)
+
+    def update_use_case_model_link_tags(self, use_case_id: str, model_link_id: str, tags: dict):
+        """
+        Update tags of use case model link
+
+        Parameters
+        ----------
+        use_case_id : str
+            use case id
+        model_link_id : str
+            use case model link id
+        tags : dict
+            model tags like {"key": "value"}
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        HTTPError
+            When API request returns error
+        """
+
+        path = f"use_cases/{use_case_id}/model_links/{model_link_id}"
+        data = {"tags": tags, "$type": "use_case_model_links", "id": model_link_id}
+        return self._client.patch(path, data)        

--- a/connect/governance/credo_api.py
+++ b/connect/governance/credo_api.py
@@ -187,3 +187,30 @@ class CredoApi:
         path = f"use_cases/{use_case_id}/model_links/{model_link_id}"
         data = {"tags": tags, "$type": "use_case_model_links", "id": model_link_id}
         return self._client.patch(path, data)        
+
+    def update_use_case_model_link_version(self, use_case_id: str, model_link_id: str, version: str):
+        """
+        Update version of use case model link
+
+        Parameters
+        ----------
+        use_case_id : str
+            use case id
+        model_link_id : str
+            use case model link id
+        version : str
+            model version
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        HTTPError
+            When API request returns error
+        """
+
+        path = f"use_cases/{use_case_id}/model_links/{model_link_id}"
+        data = {"model_version": version, "$type": "use_case_model_links", "id": model_link_id}
+        return self._client.patch(path, data)        

--- a/connect/governance/credo_api_client.py
+++ b/connect/governance/credo_api_client.py
@@ -148,6 +148,12 @@ class CredoApiClient:
             self.refresh_token()
             response = self._session.request(method, endpoint, **kwargs)
 
+        if response.status_code >= 400:
+            data = response.json()
+            if data:
+                for error in data.get("errors", []):
+                    global_logger.error(f"Error happened from [{method.upper()}] {endpoint} : Message={error['title']}, Error Detail={error['detail']}")
+
         response.raise_for_status()
 
         if response.content:

--- a/connect/governance/credo_api_client.py
+++ b/connect/governance/credo_api_client.py
@@ -152,7 +152,9 @@ class CredoApiClient:
             data = response.json()
             if data:
                 for error in data.get("errors", []):
-                    global_logger.error(f"Error happened from [{method.upper()}] {endpoint} : Message={error['title']}, Error Detail={error['detail']}")
+                    global_logger.error(
+                        f"Error happened from [{method.upper()}] {endpoint} : Message={error['title']}, Error Detail={error['detail']}"
+                    )
 
         response.raise_for_status()
 

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -406,16 +406,24 @@ class Governance:
         plan_model_tags = plan_model.get("tags", {}) or {}
         # Update model tags if changed
         if plan_model_tags != model_tags:
-            global_logger.info(f"Model tags are changed from {plan_model_tags} to {model_tags}. Updating model tags...")
-            self._api.update_use_case_model_link_tags(self._use_case_id, plan_model["id"], model_tags)
+            global_logger.info(
+                f"Model tags are changed from {plan_model_tags} to {model_tags}. Updating model tags..."
+            )
+            self._api.update_use_case_model_link_tags(
+                self._use_case_id, plan_model["id"], model_tags
+            )
             plan_model["tags"] = model_tags
 
         model_version = self.model.get("version", None)
         plan_model_version = plan_model.get("model_version", None)
         # Update model version if changed
         if plan_model_version != model_version:
-            global_logger.info(f"Model version is changed from {plan_model_version} to {model_version}. Updating model version...")
-            self._api.update_use_case_model_link_version(self._use_case_id, plan_model["id"], model_version)
+            global_logger.info(
+                f"Model version is changed from {plan_model_version} to {model_version}. Updating model version..."
+            )
+            self._api.update_use_case_model_link_version(
+                self._use_case_id, plan_model["id"], model_version
+            )
             plan_model["model_version"] = model_version
 
     def _print_model_changes_log(self):
@@ -428,29 +436,37 @@ class Governance:
         plan_model_tags = plan_model.get("tags", {}) or {}
         # Update model tags if changed
         if plan_model_tags != model_tags:
-            global_logger.info(f"Model tags are changed from {plan_model_tags} to {model_tags}")
+            global_logger.info(
+                f"Model tags are changed from {plan_model_tags} to {model_tags}"
+            )
 
         model_version = self.model.get("version", None)
         plan_model_version = plan_model.get("model_version", None)
         # Update model version if changed
         if plan_model_version != model_version:
-            global_logger.info(f"Model version is changed from {plan_model_version} to {model_version}")
+            global_logger.info(
+                f"Model version is changed from {plan_model_version} to {model_version}"
+            )
 
         if plan_model_tags != model_tags or plan_model_version != model_version:
-            global_logger.info(f"You can apply changes to governance by calling the following method")
+            global_logger.info(
+                f"You can apply changes to governance by calling the following method"
+            )
             global_logger.info(f"  gov.apply_model_changes()")
-            global_logger.info(f"Or calling gov.export() method will automatically apply changes to governance")
+            global_logger.info(
+                f"Or calling gov.export() method will automatically apply changes to governance"
+            )
 
     def _find_plan_model(self):
         model_name = self.model.get("name", None)
-        if model_name is None: 
-            return None 
+        if model_name is None:
+            return None
 
         for link in self._plan.get("model_links", []):
             if link["model_name"] == model_name:
                 return link
-                
-        return None              
+
+        return None
 
     def _check_inclusion(self, label, evidence):
         matching_evidence = []

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -328,6 +328,7 @@ class Governance:
             prepared_model["assessment_dataset_name"] = assessment_dataset
         self._model = prepared_model
 
+
     def set_evidence(self, evidences: List[Evidence]):
         """
         Update evidences
@@ -392,25 +393,27 @@ class Governance:
 
     def _update_model_link(self):
         # find model_link with model name from assessment plan
-        model_link = self._find_model_link_from_assessment_plan()
-        if model_link is None:
+        plan_model = self._find_plan_model()
+        if plan_model is None:
             return
 
         model_tags = self.model.get("tags", {}) or {}
-        model_link_tags = model_link.get("tags", {}) or {}
+        plan_model_tags = plan_model.get("tags", {}) or {}
         # Update model tags if changed
-        if model_link_tags != model_tags:
-            global_logger.info(f"Model tags are changed from {model_link_tags} to {model_tags}. Updating model tags...")
-            self._api.update_use_case_model_link_tags(self._use_case_id, model_link["id"], model_tags)
+        if plan_model_tags != model_tags:
+            global_logger.info(f"Model tags are changed from {plan_model_tags} to {model_tags}. Updating model tags...")
+            self._api.update_use_case_model_link_tags(self._use_case_id, plan_model["id"], model_tags)
 
         model_version = self.model.get("version", None)
-        model_link_version = model_link.get("version", None)
+        plan_model_version = plan_model.get("version", None)
         # Update model version if changed
-        if model_link_version != model_version:
-            global_logger.info(f"Model version is changed from {model_link_version} to {model_version}. Updating model version...")
-            self._api.update_use_case_model_link_version(self._use_case_id, model_link["id"], model_version)
+        if plan_model_version != model_version:
+            global_logger.info(f"Model version is changed from {plan_model_version} to {model_version}. Updating model version...")
+            self._api.update_use_case_model_link_version(self._use_case_id, plan_model["id"], model_version)
 
-    def _find_model_link_from_assessment_plan(self):
+
+
+    def _find_plan_model(self):
         model_name = self.model.get("name", None)
         if model_name is None: 
             return None 

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -103,6 +103,40 @@ class Governance:
         """
         self._evidences += wrap_list(evidences)
 
+    def apply_model_changes(self):
+        """
+        Update Platform model's tags and version to CredoAI Governance if changed
+
+        This function will update the platform model associated with the assessment plan with
+        the tags and version associated with the local model associated with Governance. If no
+        model has been registered on the platform, nothing will be updated.
+        """
+        # association between keys and api calls:
+        api_calls = {
+            "tags": self._api.update_use_case_model_link_tags,
+            "model_version": self._api.update_use_case_model_link_version,
+        }
+
+        # find model_link with model name from assessment plan
+        plan_model = self._find_plan_model()
+        if plan_model is None:
+            return
+
+        model_info = self.get_model_info()
+        plan_model_info = self._get_model_info(plan_model)
+        for key in model_info.keys():
+            model_value = model_info[key]
+            plan_model_value = plan_model[key]
+            if model_value != plan_model_value:
+                global_logger.info(
+                    "%s\n%s",
+                    f"Platform model and local model {key} do not match. Platform {key}: {plan_model_value}, Local {key}: {model_value}\n",
+                    f"Updated platform model {key}...",
+                )
+                api_call = api_calls[key]
+                api_call(self._use_case_id, plan_model["id"], model_value)
+                plan_model[key] = model_value
+
     def clear_evidence(self):
         self.set_evidence([])
 
@@ -174,7 +208,7 @@ class Governance:
         List[EvidenceRequirement]
         """
         if tags is None:
-            tags = self.get_model_tags()
+            tags = self.get_model_info()["tags"]
 
         reqs = [e for e in self._evidence_requirements if check_subset(e.tags, tags)]
         if verbose:
@@ -185,19 +219,9 @@ class Governance:
         """Return the unique tags used for all evidence requirements"""
         return self._unique_tags
 
-    def get_model_tags(self):
-        """Get the tags for the associated model"""
-        if self._model:
-            return self._model["tags"]
-        else:
-            return {}
-
-    def get_model_version(self):
-        """Get the version for the associated model"""
-        if self._model:
-            return self._model.get("version", None)
-        else:
-            return {}
+    def get_model_info(self):
+        """Get the tags and version for the associated model"""
+        return self._get_model_info(self._model)
 
     def register(
         self,
@@ -321,7 +345,11 @@ class Governance:
         global_logger.info(
             f"Adding model ({model}) to governance. Model has tags: {model_tags} and version: {model_version}"
         )
-        prepared_model = {"name": model, "tags": model_tags, "version": model_version}
+        prepared_model = {
+            "name": model,
+            "tags": model_tags,
+            "model_version": model_version,
+        }
         if training_dataset:
             prepared_model["training_dataset_name"] = training_dataset
         if assessment_dataset:
@@ -392,87 +420,31 @@ class Governance:
                 error = assessment["error"]
                 global_logger.error(f"Error in uploading evidences : {error}")
 
-    def apply_model_changes(self):
-        """
-        Update model's tags and version to CredoAI Governance if changed
-        """
-
-        # find model_link with model name from assessment plan
-        plan_model = self._find_plan_model()
-        if plan_model is None:
-            return
-
-        model_tags = self.model.get("tags", {}) or {}
-        plan_model_tags = plan_model.get("tags", {}) or {}
-        # Update model tags if changed
-        if plan_model_tags != model_tags:
-            global_logger.info(
-                f"Model tags are changed from {plan_model_tags} to {model_tags}. Updating model tags..."
-            )
-            self._api.update_use_case_model_link_tags(
-                self._use_case_id, plan_model["id"], model_tags
-            )
-            plan_model["tags"] = model_tags
-
-        model_version = self.model.get("version", None)
-        plan_model_version = plan_model.get("model_version", None)
-        # Update model version if changed
-        if plan_model_version != model_version:
-            global_logger.info(
-                f"Model version is changed from {plan_model_version} to {model_version}. Updating model version..."
-            )
-            self._api.update_use_case_model_link_version(
-                self._use_case_id, plan_model["id"], model_version
-            )
-            plan_model["model_version"] = model_version
-
     def _print_model_changes_log(self):
         # find model_link with model name from assessment plan
         plan_model = self._find_plan_model()
         if plan_model is None:
             return
 
-        model_tags = self.model.get("tags", {}) or {}
-        plan_model_tags = plan_model.get("tags", {}) or {}
-        # Update model tags if changed
-        if plan_model_tags != model_tags:
+        model_info = self.get_model_info()
+        plan_model_info = self._get_model_info(plan_model)
+        match = True
+        for key in model_info.keys():
+            model_value = model_info[key]
+            plan_model_value = plan_model[key]
+            if model_value != plan_model_value:
+                match = False
+                global_logger.info(
+                    f"Platform model and local model {key} do not match. Platform {key}: {plan_model_value}, Local {key}: {model_value}"
+                )
+        if not match:
             global_logger.info(
-                f"Model tags are changed from {plan_model_tags} to {model_tags}"
+                """
+        You can apply changes to governance by calling the following method:
+            gov.apply_model_changes()
+        Alternatively, calling gov.export() method will automatically apply changes to governance.
+                """
             )
-
-        model_version = self.model.get("version", None)
-        plan_model_version = plan_model.get("model_version", None)
-        # Update model version if changed
-        if plan_model_version != model_version:
-            global_logger.info(
-                f"Model version is changed from {plan_model_version} to {model_version}"
-            )
-
-        if plan_model_tags != model_tags or plan_model_version != model_version:
-            global_logger.info(
-                f"You can apply changes to governance by calling the following method"
-            )
-            global_logger.info(f"  gov.apply_model_changes()")
-            global_logger.info(
-                f"Or calling gov.export() method will automatically apply changes to governance"
-            )
-
-    def _find_plan_model(self):
-        if self.model is None:
-            return None
-
-        model_name = self.model.get("name", None)
-        if model_name is None:
-            return None
-
-        if self._plan is None:
-            return None
-
-        for link in self._plan.get("model_links", []):
-            if link["model_name"] == model_name:
-                return link
-
-        return None
 
     def _check_inclusion(self, label, evidence):
         matching_evidence = []
@@ -502,6 +474,31 @@ class Governance:
         data = json_dumps(serialize(data=data, meta=meta))
         with open(filename, "w") as f:
             f.write(data)
+
+    def _find_plan_model(self):
+        """Return model from assessment plan who matches name of associated model"""
+        if self.model is None or self._plan is None:
+            return None
+
+        model_name = self.model.get("name", None)
+        if model_name is None:
+            return None
+
+        for link in self._plan.get("model_links", []):
+            if link["model_name"] == model_name:
+                return link
+
+        return None
+
+    def _get_model_info(self, model):
+        """Get the tags and version for a model"""
+        if model:
+            return {
+                "tags": model.get("tags", {}),
+                "model_version": model.get("model_version", None),
+            }
+        else:
+            return {"tags": {}, "model_version": None}
 
     def _match_requirements(self):
         missing = []

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -328,6 +328,7 @@ class Governance:
             prepared_model["assessment_dataset_name"] = assessment_dataset
         self._model = prepared_model
 
+        self._print_model_changes_log()
 
     def set_evidence(self, evidences: List[Evidence]):
         """
@@ -411,7 +412,28 @@ class Governance:
             global_logger.info(f"Model version is changed from {plan_model_version} to {model_version}. Updating model version...")
             self._api.update_use_case_model_link_version(self._use_case_id, plan_model["id"], model_version)
 
+    def _print_model_changes_log(self):
+        # find model_link with model name from assessment plan
+        plan_model = self._find_plan_model()
+        if plan_model is None:
+            return
 
+        model_tags = self.model.get("tags", {}) or {}
+        plan_model_tags = plan_model.get("tags", {}) or {}
+        # Update model tags if changed
+        if plan_model_tags != model_tags:
+            global_logger.info(f"Model tags are changed from {plan_model_tags} to {model_tags}")
+
+        model_version = self.model.get("version", None)
+        plan_model_version = plan_model.get("version", None)
+        # Update model version if changed
+        if plan_model_version != model_version:
+            global_logger.info(f"Model version is changed from {plan_model_version} to {model_version}")
+
+        if plan_model_tags != model_tags or plan_model_version != model_version:
+            global_logger.info(f"You can apply changes to governance by calling the following method")
+            global_logger.info(f"  gov.update_model_link()")
+            global_logger.info(f"Or calling gov.export() method will automatically apply changes to governance")
 
     def _find_plan_model(self):
         model_name = self.model.get("name", None)

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -408,13 +408,15 @@ class Governance:
         if plan_model_tags != model_tags:
             global_logger.info(f"Model tags are changed from {plan_model_tags} to {model_tags}. Updating model tags...")
             self._api.update_use_case_model_link_tags(self._use_case_id, plan_model["id"], model_tags)
+            plan_model["tags"] = model_tags
 
         model_version = self.model.get("version", None)
-        plan_model_version = plan_model.get("version", None)
+        plan_model_version = plan_model.get("model_version", None)
         # Update model version if changed
         if plan_model_version != model_version:
             global_logger.info(f"Model version is changed from {plan_model_version} to {model_version}. Updating model version...")
             self._api.update_use_case_model_link_version(self._use_case_id, plan_model["id"], model_version)
+            plan_model["model_version"] = model_version
 
     def _print_model_changes_log(self):
         # find model_link with model name from assessment plan

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -297,7 +297,7 @@ class Governance:
         self,
         model: str,
         model_tags: dict,
-        model_version: str,
+        model_version: str = None,
         training_dataset: str = None,
         assessment_dataset: str = None,
     ):
@@ -458,8 +458,14 @@ class Governance:
             )
 
     def _find_plan_model(self):
+        if self.model is None:
+            return None
+
         model_name = self.model.get("name", None)
         if model_name is None:
+            return None
+
+        if self._plan is None:
             return None
 
         for link in self._plan.get("model_links", []):

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -394,7 +394,7 @@ class Governance:
 
     def apply_model_changes(self):
         """
-        Update model's tags and version to governance if changed
+        Update model's tags and version to CredoAI Governance if changed
         """
 
         # find model_link with model name from assessment plan

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -359,7 +359,7 @@ class Governance:
         )
 
         # update when model tags are changed
-        self._update_model_link()
+        self.apply_model_changes()
 
         assessment = self._api.create_assessment(
             self._use_case_id, self._prepare_export_data()
@@ -392,7 +392,11 @@ class Governance:
                 error = assessment["error"]
                 global_logger.error(f"Error in uploading evidences : {error}")
 
-    def _update_model_link(self):
+    def apply_model_changes(self):
+        """
+        Update model's tags and version to governance if changed
+        """
+
         # find model_link with model name from assessment plan
         plan_model = self._find_plan_model()
         if plan_model is None:
@@ -425,14 +429,14 @@ class Governance:
             global_logger.info(f"Model tags are changed from {plan_model_tags} to {model_tags}")
 
         model_version = self.model.get("version", None)
-        plan_model_version = plan_model.get("version", None)
+        plan_model_version = plan_model.get("model_version", None)
         # Update model version if changed
         if plan_model_version != model_version:
             global_logger.info(f"Model version is changed from {plan_model_version} to {model_version}")
 
         if plan_model_tags != model_tags or plan_model_version != model_version:
             global_logger.info(f"You can apply changes to governance by calling the following method")
-            global_logger.info(f"  gov.update_model_link()")
+            global_logger.info(f"  gov.apply_model_changes()")
             global_logger.info(f"Or calling gov.export() method will automatically apply changes to governance")
 
     def _find_plan_model(self):

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -192,6 +192,13 @@ class Governance:
         else:
             return {}
 
+    def get_model_version(self):
+        """Get the version for the associated model"""
+        if self._model:
+            return self._model.get("version", None)
+        else:
+            return {}
+
     def register(
         self,
         assessment_plan_url: str = None,
@@ -290,6 +297,7 @@ class Governance:
         self,
         model: str,
         model_tags: dict,
+        model_version: str,
         training_dataset: str = None,
         assessment_dataset: str = None,
     ):
@@ -311,9 +319,9 @@ class Governance:
         """
 
         global_logger.info(
-            f"Adding model ({model}) to governance. Model has tags: {model_tags}"
+            f"Adding model ({model}) to governance. Model has tags: {model_tags} and version: {model_version}"
         )
-        prepared_model = {"name": model, "tags": model_tags}
+        prepared_model = {"name": model, "tags": model_tags, "version": model_version}
         if training_dataset:
             prepared_model["training_dataset_name"] = training_dataset
         if assessment_dataset:
@@ -394,6 +402,13 @@ class Governance:
         if model_link_tags != model_tags:
             global_logger.info(f"Model tags are changed from {model_link_tags} to {model_tags}. Updating model tags...")
             self._api.update_use_case_model_link_tags(self._use_case_id, model_link["id"], model_tags)
+
+        model_version = self.model.get("version", None)
+        model_link_version = model_link.get("version", None)
+        # Update model version if changed
+        if model_link_version != model_version:
+            global_logger.info(f"Model version is changed from {model_link_version} to {model_version}. Updating model version...")
+            self._api.update_use_case_model_link_version(self._use_case_id, model_link["id"], model_version)
 
     def _find_model_link_from_assessment_plan(self):
         model_name = self.model.get("name", None)


### PR DESCRIPTION
## Change description
- Assessment Plan now includes model_links, Backend PR : https://github.com/credo-ai/credo-backend/pull/995 
   So now the user knows existing tags and version of the model.
- Added APIs to update model version or model tags
- Update Governance._api_export method. Now it updates model tags and version if changed with separate API call before uploading evidences.
- Added model version to Adapter and Governance, so user can set and update model version.
- `Governance.set_artifacts` now shows log message when tags or version is changed. @IanAtCredo  Please remove this message does not make sense.
- `Governance.apply_model_changes` updates the governance backend with API calls.

```python
import connect as ct

gov = ct.Governance()  
url = 'http://localhost:4000/api/v2/credoai/use_cases/Xr3uT5fet6vPNbkFkuax5d/assessment_plans/NYCE+12'
gov.register(assessment_plan_url=url)

adapter = ct.Adapter(governance = gov, model_name='credit_default_classifier', model_version="1.8", model_tags={'model_type': 'binary'})

# Messages
# 2023-01-18 18:13:56,187 - connect - INFO - Adding model (credit_default_classifier) to governance. Model has tags: {'model_type': 'binary'} and version: 1.9
# 2023-01-18 18:13:56,188 - connect - INFO - Model version is changed from 1.8 to 1.9
# 2023-01-18 18:13:56,188 - connect - INFO - You can apply changes to governance by calling the following method
# 2023-01-18 18:13:56,189 - connect - INFO -   gov.apply_model_changes()
# 2023-01-18 18:13:56,189 - connect - INFO - Or calling gov.export() method will automatically apply changes to governance

gov.apply_model_changes()

# Messages
# 2023-01-18 18:14:30,250 - connect - INFO - Model version is changed from 1.8 to 1.9. Updating model version...

source = f"Quickstart_Connect-{ct.__version__}"
adapter.metrics_to_governance(metrics=assessments, source = source)

gov.export()
```