### PR TITLE
Feat/send images (WIP)

### DIFF
--- a/connect/_version.py
+++ b/connect/_version.py
@@ -2,4 +2,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -3,7 +3,12 @@ from typing import Optional
 
 import pandas as pd
 
-from connect.evidence import EvidenceContainer, MetricContainer, TableContainer
+from connect.evidence import (
+    EvidenceContainer,
+    FigureContainer,
+    MetricContainer,
+    TableContainer,
+)
 from connect.governance import Governance
 from connect.utils import ValidationError, wrap_list
 
@@ -37,6 +42,39 @@ class Adapter:
         self.governance = governance
         self.governance.set_artifacts(
             model_name, model_tags, model_version, assessment_dataset_name
+        )
+
+    def figure_to_governance(
+        self,
+        data: dict,
+        source: str,
+        labels: dict = None,
+        metadata: dict = None,
+        overwrite_governance: bool = True,
+    ):
+        """
+        Packages metrics as evidence and sends them to governance
+
+        Parameters
+        ---------
+        data: dict
+            Dictionary to pass to evidence_fun. The dictionary must have a "figure" and "title"
+            key. See FigureContainer for more details
+        source : str
+            Label for what generated the table. Added to metadata
+        labels : dict
+            Additional key/value pairs to act as labels for the evidence
+        metadata : dict
+            Metadata to pass to underlying evidence
+        overwrite_governance : bool
+            When adding evidence to a Governance object, whether to overwrite existing
+            evidence or not, default False.
+        evidence_fun : callable
+            Function to pass data, labels and metadata. The function should return a list of
+            evidence. Default: self._to_evidence
+        """
+        self._evidence_to_governance(
+            FigureContainer, data, source, labels, metadata, overwrite_governance
         )
 
     def metrics_to_governance(

--- a/connect/evidence/__init__.py
+++ b/connect/evidence/__init__.py
@@ -6,9 +6,16 @@ Credo AI Platform API
 """
 from .containers import (
     EvidenceContainer,
+    FigureContainer,
     MetricContainer,
-    TableContainer,
     StatisticTestContainer,
+    TableContainer,
 )
-from .evidence import Evidence, MetricEvidence, TableEvidence, StatisticTestEvidence
+from .evidence import (
+    Evidence,
+    FigureEvidence,
+    MetricEvidence,
+    StatisticTestEvidence,
+    TableEvidence,
+)
 from .evidence_requirement import EvidenceRequirement

--- a/connect/evidence/evidence.py
+++ b/connect/evidence/evidence.py
@@ -65,6 +65,54 @@ class Evidence(ABC):
         pass
 
 
+class FigureEvidence(Evidence):
+    """
+    Evidence for Figure
+
+    Parameters
+    ----------
+    title : string
+        short identifier for metric.
+    figure : float
+        metric value
+    confidence_interval : [float, float]
+        [lower, upper] confidence interval
+    confidence_level : int
+        Level of confidence for the confidence interval (e.g., 95%)
+    metadata : dict, optional
+        Arbitrary keyword arguments to append to metric as metadata. These will be
+        displayed in the governance app
+    """
+
+    def __init__(
+        self,
+        title,
+        figure,
+        content_type=None,
+        description=None,
+        additional_labels=None,
+        **metadata
+    ):
+        self.title = title
+        self.figure = figure
+        self.description = description
+        self.content_type = content_type
+        super().__init__("figure", additional_labels, **metadata)
+
+    @property
+    def data(self):
+        return {
+            "file": self.figure,
+            "description": self.description,
+            "content_type": self.content_type,
+        }
+
+    @property
+    def base_label(self):
+        label = {"title": self.title}
+        return label
+
+
 class MetricEvidence(Evidence):
     """
     Evidence for Metric:value result type

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ URL = ""
 LICENSE = ""
 DOWNLOAD_URL = "https://github.com/credo-ai/credoai_connect"
 VERSION = __version__
-PYTHON_REQUIRES = ">=3.8"
+PYTHON_REQUIRES = ">=3.7"
 
 # Fetch ReadMe
 with open("README.md", "r") as fh:
@@ -37,6 +37,7 @@ EXTRAS_REQUIRES = {"dev": dev_requirements}
 CLASSIFIERS = [
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
## Change description

We want `connect` to be able to send figures to the platform. This is part of further empowering the data scientist to interact with the platform from their development environment. This is a new evidence type: "figure". 

The figure evidence type has a label, like any other evidence type. The data has a "file", which is a base64 encoded image, a "description" and a "content_type". I'm actually unsure if content_type is needed by the platform @aproxacs 

Example
```
{'type': 'figure',
 'label': {'title': 'hey'},
 'data': {'file': 'iVBORw...',
  'description': 'Example',
  'content_type': 'image/png'},
 'generated_at': '2023-02-01T19:43:48.467621',
 'metadata': {}}
```

@aproxacs, not sure if there was ever a ticket made on the engineering side, but got this started. If anything seems like it should be changed, please let me know.