### PR TITLE
Fixing disappearance of requirements after adapter init

### DIFF
--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -33,7 +33,7 @@ class Adapter:
         model_version: Optional[str] = None,
         assessment_dataset_name: str = None,
     ):
-
+        model_tags = model_tags or {}
         self.governance = governance
         self.governance.set_artifacts(
             model_name, model_tags, model_version, assessment_dataset_name

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -497,6 +497,7 @@ class Governance:
     def _get_model_info(self, model):
         """Get the tags and version for a model"""
         if model:
+            model = {k: v for k, v in model.items() if v}
             return {
                 "tags": model.get("tags", {}),
                 "model_version": model.get("model_version", None),

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -497,7 +497,6 @@ class Governance:
     def _get_model_info(self, model):
         """Get the tags and version for a model"""
         if model:
-            model = {k: v for k, v in model.items() if v}
             return {
                 "tags": model.get("tags", {}),
                 "model_version": model.get("model_version", None),


### PR DESCRIPTION
## Description of the issue

In the case in which tags are missing, after initing the adapter, the `model_tags` parameter  is defaulted to `None`.

When running `gov.get_evidence_requirements`, the chain of calls is:

1. `tags = self.get_model_info()["tags"]` 
2. `self._get_model_info`

Here since "tags" is in model (value = None), `model.get("tags", {})` simply returns the None rather then defaulting to `{}`.

So when `check_subset` is run in `get_evidence_requirements`, no matches are found.

## Solutions

Either of these fixes it:

- Enforcing default behavior for None model_info (this is the change I have made)
- Enforcing empty dictionary as default at `Adapter` init:

``` 
def __init__(
        self,
        governance: Governance,
        model_name: str,
        model_tags: Optional[dict] ={}, # Changed here!
        model_version: Optional[str] = None,
        assessment_dataset_name: str = None,
   ):
```

@esherman-credo let me know which one you think it's best.



