### PR TITLE
DEV-309 Set access_token from assessment_plan_url

### DIFF
--- a/connect/governance/credo_api_client.py
+++ b/connect/governance/credo_api_client.py
@@ -72,7 +72,7 @@ class CredoApiConfig:
         config_path = config_path or self.default_config_path()
 
         if not os.path.exists(config_path):
-            self.logger.error("Path to config file Not Found")
+            # self.logger.error("Path to config file Not Found")
             # return example
             self._api_key = None
             self._tenant = None
@@ -108,6 +108,7 @@ class CredoApiClient:
             self._config = CredoApiConfig()
             self._config.load_config(config_path=config_path)
 
+        self._api_base = self._config.api_base
         self._session = requests.Session()
         self.refresh_token()
 
@@ -135,6 +136,9 @@ class CredoApiClient:
             "X-Client-Version": get_version(),
         }
         self._session.headers.update(headers)
+
+    def set_api_base(self, value):
+        self._api_base = value
 
     def __make_request(self, method: str, path: str, **kwargs):
 
@@ -164,7 +168,7 @@ class CredoApiClient:
             return None
 
     def __build_endpoint(self, path):
-        return os.path.join(self._config.api_base, path)
+        return os.path.join(self._api_base, path)
 
     def get(self, path: str, **kwargs):
         """

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -5,6 +5,7 @@ Credo Governance
 import json
 import sys
 import time
+from urllib.parse import urlparse, parse_qs
 from pprint import pprint
 from typing import List, Optional, Union
 
@@ -280,6 +281,13 @@ class Governance:
             )
 
         if assessment_plan_url:
+            api_base, access_token = self._parse_assessment_plan_url(
+                assessment_plan_url
+            )
+            if api_base and access_token:
+                self._api._client.set_access_token(access_token)
+                self._api._client.set_api_base(api_base)
+
             plan = self._api.get_assessment_plan(assessment_plan_url)
 
         if assessment_plan:
@@ -317,6 +325,12 @@ class Governance:
                 )
 
             self.clear_evidence()
+
+    def _parse_assessment_plan_url(self, assessment_plan_url):
+        api_base = assessment_plan_url.split("/use_cases/")[0]
+        result = urlparse(assessment_plan_url)
+        query = parse_qs(result.query)
+        return api_base, query.get("access_token", [None])[0]
 
     def set_artifacts(
         self,


### PR DESCRIPTION
## Change description
Vendor portal users do not use API key. Instead, `assessment_plan_url` they get includes `access_token`. To support this, if the `access_token` is included in the `assessment_plan_url`, sets' client's `access_token` and `api_base` with it.

related PR : https://github.com/credo-ai/vendor-portal/pull/10
