### PR TITLE
DEV-368: set model_version default to empty string

### DIFF
--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -30,7 +30,7 @@ class Adapter:
         governance: Governance,
         model_name: str,
         model_tags: Optional[dict] = None,
-        model_version: Optional[str] = None,
+        model_version: Optional[str] = "",
         assessment_dataset_name: str = None,
     ):
         model_tags = model_tags or {}

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -322,7 +322,7 @@ class Governance:
         self,
         model: str,
         model_tags: dict,
-        model_version: str = None,
+        model_version: str = "",
         training_dataset: str = None,
         assessment_dataset: str = None,
     ):
@@ -337,6 +337,8 @@ class Governance:
             List of key:value pairs specifying model tags. These are typically
             used to pair the model with tagged governance requirements,
             which are defined in a Governance instance's assessment_plan
+        model_version : str
+            Model Version, by default "" (API will convert null values to "")
         training_dataset : str, optional
             training dataset name, by default None
         assessment_dataset : str, optional
@@ -499,10 +501,10 @@ class Governance:
         if model:
             return {
                 "tags": model.get("tags", {}),
-                "model_version": model.get("model_version", None),
+                "model_version": model.get("model_version", ""),
             }
         else:
-            return {"tags": {}, "model_version": None}
+            return {"tags": {}, "model_version": ""}
 
     def _match_requirements(self):
         missing = []


### PR DESCRIPTION
## Change description

Addresses DEV-368

The API service will convert null value to `""` before storing in the database.  Connect should know that default should be empty string, otherwise, it might assume null is valid since the API will gladly accept it.  The issue comes when the code tries to compare local evidence object with the one returned by the API.  `"" != null` so it will think there is a version mismatch.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
