### PR TITLE
DEV-368: set model_version default to empty string

### DIFF
--- a/connect/adapters/adapters.py
+++ b/connect/adapters/adapters.py
@@ -21,6 +21,8 @@ class Adapter:
         List of key:value pairs specifying model tags. These are typically
         used to pair the model with tagged governance requirements,
         which are defined in a Governance instance's assessment_plan
+    model_version : str, optional
+        Version of the model
     assessment_dataset_name : dict, optional
         Name of dataset used to assess the model
     """
@@ -30,7 +32,7 @@ class Adapter:
         governance: Governance,
         model_name: str,
         model_tags: Optional[dict] = None,
-        model_version: Optional[str] = None,
+        model_version: Optional[str] = str(),
         assessment_dataset_name: str = None,
     ):
         model_tags = model_tags or {}

--- a/connect/governance/governance.py
+++ b/connect/governance/governance.py
@@ -322,7 +322,7 @@ class Governance:
         self,
         model: str,
         model_tags: dict,
-        model_version: str = None,
+        model_version: str = str(),
         training_dataset: str = None,
         assessment_dataset: str = None,
     ):
@@ -337,6 +337,8 @@ class Governance:
             List of key:value pairs specifying model tags. These are typically
             used to pair the model with tagged governance requirements,
             which are defined in a Governance instance's assessment_plan
+        model_version : str, optional
+            the model version, by default ""
         training_dataset : str, optional
             training dataset name, by default None
         assessment_dataset : str, optional
@@ -499,10 +501,10 @@ class Governance:
         if model:
             return {
                 "tags": model.get("tags", {}),
-                "model_version": model.get("model_version", None),
+                "model_version": model.get("model_version", str()),
             }
         else:
-            return {"tags": {}, "model_version": None}
+            return {"tags": {}, "model_version": str()}
 
     def _match_requirements(self):
         missing = []


### PR DESCRIPTION
## Change description

The default model_version should be empty string `""` because null is stored (and returned) as empty string from the server.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

* Related to DEV-368 but not a fix for whatever caused the 401.

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
