### PR TITLE
Hotfix loggingfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,10 @@ Documentation is hosted by [readthedocs](https://credoai-connect.readthedocs.io/
 
 
 ## Logging
-In order to collect all logging information into a specific file, please insert the path to the folder that
-will contain the file in the environment variable `CREDO_CONNECT_LOG_PATH`. For example:
+Logging defaults to stdout. In order to collect all logging information into a specific file,
+set the desired location to the environment variable `CREDO_CONNECT_LOG_PATH`. 
 
-```python
-# To create the log file in the local folder
-CREDO_CONNECT_LOG_PATH="."
-```
+
 
 > **Warning**
 > Make sure the destination has write permissions, otherwise you will get a `PermissionError` at the moment you

--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ pip install credoai-connect
 ## Documentation
 
 Documentation is hosted by [readthedocs](https://credoai-connect.readthedocs.io/en/stable/).
+
+
+## Logging
+In order to collect all logging information into a specific file, please insert the path to the folder that
+will contain the file in the environment variable `CREDO_CONNECT_LOG_PATH`. For example:
+
+```python
+# To create the log file in the local folder
+CREDO_CONNECT_LOG_PATH="."
+```
+
+> **Warning**
+> Make sure the destination has write permissions, otherwise you will get a `PermissionError` at the moment you
+> attempt library import.

--- a/connect/utils/logging.py
+++ b/connect/utils/logging.py
@@ -2,6 +2,7 @@ from collections import deque
 from io import StringIO
 from logging import FileHandler, Formatter, Handler, StreamHandler, getLogger
 from os.path import join
+from os import getenv
 from sys import stdout
 
 
@@ -67,9 +68,10 @@ class Logger:
         self.logger.addHandler(file_handler)
 
 
-def setup_logger(name="connect", path=None, record_stream=False, logging_level="INFO"):
+def setup_logger(name="connect", record_stream=False, logging_level="INFO"):
+    path = getenv("CREDO_CONNECT_LOG_PATH")
     tmp = Logger(name, path, record_stream, logging_level)
     return tmp.logger, tmp.stream
 
 
-global_logger, global_tail = setup_logger(path=".")
+global_logger, global_tail = setup_logger()


### PR DESCRIPTION
## Removed pre-set destination for logging file

The global logger was set to create a logging file in `"."` by default. This was problematic when connect is run in an environment that lacks writing permissions.

Fix:
- Removed the global file path preset
- Connect will default to stdout/stream for the logs
- Added the possibility of specifying a logging path destination via environment variable. This is the easiest solution to retain the capability of logging to a file in a configurable destination.
- Added the info to the README file.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

